### PR TITLE
Fixing issue when iTunes Connect is misbehaving.

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,10 @@ Connect.prototype.executeRequest = function(task, callback) {
 			'Cookie': this._cookies
 		}
 	}, function(error, response, body) {
-		if(response.statusCode == 401) {
+		if(!response.hasOwnProperty('statusCode')){
+			error = new Error('iTunes Connect is not responding. The service may be temporarily offline.');
+			body  = null;
+		}else if(response.statusCode == 401) {
 			error = new Error('This request requires authentication. Please check your username and password.');
 			body  = null;
 		}


### PR DESCRIPTION
iTunes Connect had trouble 2015-06-02 16:30:00 UTC for around 30 minutes preventing me from being able to log in. At the same time the iTunesConnector node module was erroring - the response object was an empty object. I can't reproduce the error but I have supplied a simple fix to check if the statuscode property exists on the response object before calling it.

You may be able to resolve this issue elsewhere in the code base.
